### PR TITLE
Support for tables with camelcase

### DIFF
--- a/vacuum/last_autovacuum.sql
+++ b/vacuum/last_autovacuum.sql
@@ -2,9 +2,9 @@
 select
     pg_class.relname,
     pg_namespace.nspname,
-    pg_size_pretty(pg_total_relation_size(pg_namespace.nspname::text || '.' || pg_class.relname::text)),
+    pg_size_pretty(pg_total_relation_size('"' || pg_namespace.nspname::text || '"' || '.' || '"' || pg_class.relname::text || '"')),
     pg_stat_all_tables.last_autovacuum,
-    pg_relation_size(pg_namespace.nspname::text || '.' || pg_class.relname::text)
+    pg_relation_size('"' || pg_namespace.nspname::text || '"' || '.' || '"' || pg_class.relname::text || '"')
 from
     pg_class
         join pg_namespace


### PR DESCRIPTION
Without quoatation, you will get an error like

> ERROR:  relation "public.table_with_camelcase" does not exist
> SQL state: 42P01

if a table with name like **table_with_camelCase** exists..