### PR TITLE
Update column headers and sorting

### DIFF
--- a/bloat/index_bloat_check.sql
+++ b/bloat/index_bloat_check.sql
@@ -98,4 +98,4 @@ FROM raw_bloat
 SELECT *
 FROM format_bloat
 WHERE ( bloat_pct > 50 and bloat_mb > 10 )
-ORDER BY bloat_mb DESC;
+ORDER BY bloat_pct DESC;

--- a/bloat/table_bloat_check.sql
+++ b/bloat/table_bloat_check.sql
@@ -137,4 +137,4 @@ FROM bloat_data
 -- bloated and more than 4GB in size
 WHERE ( pct_bloat >= 50 AND mb_bloat >= 10 )
     OR ( pct_bloat >= 25 AND mb_bloat >= 1000 )
-ORDER BY pct_bloat DESC;
+ORDER BY mb_bloat DESC;

--- a/indexes/duplicate_indexes.sql
+++ b/indexes/duplicate_indexes.sql
@@ -2,20 +2,22 @@
 \o /tmp/duplicate-indexes.txt
 
 -- check for exact matches
-SELECT indrelid::regclass
-     , array_agg(indexrelid::regclass)
+SELECT indrelid::regclass AS table
+     , array_agg(indexrelid::regclass) AS duplicate_indexes
   FROM pg_index
  GROUP BY indrelid
      , indkey
-HAVING COUNT(*) > 1;
+HAVING COUNT(*) > 1
+ORDER BY indrelid::regclass;
 
 -- check for matches on only the first column of the index
 -- requires some human eyeballing to verify
-SELECT indrelid::regclass
-     , array_agg(indexrelid::regclass)
+SELECT indrelid::regclass AS table
+     , array_agg(indexrelid::regclass) AS duplicate_indexes_to_check
   FROM pg_index
  GROUP BY indrelid
      , indkey[0]
-HAVING COUNT(*) > 1;
+HAVING COUNT(*) > 1
+ORDER BY indrelid::regclass;
 
 \o


### PR DESCRIPTION
Index bloat is worse when it's a high percentage of index size, so sort on percentage bloat
Table bloat is worse when its sheer size is large, so sort on MB bloat

Update duplicate indexes checks' column names, and sort alphabetically on relname for easier checking.