### PR TITLE
Style and capitalization support update

### DIFF
--- a/vacuum/last_autovacuum.sql
+++ b/vacuum/last_autovacuum.sql
@@ -1,18 +1,23 @@
--- Show last autovacuum by table size descending.
-select
-    pg_class.relname,
-    pg_namespace.nspname,
-    pg_size_pretty(pg_total_relation_size(pg_namespace.nspname::text || '.' || pg_class.relname::text)),
-    pg_stat_all_tables.last_autovacuum,
-    pg_relation_size(pg_namespace.nspname::text || '.' || pg_class.relname::text)
-from
-    pg_class
-        join pg_namespace
-            on pg_class.relnamespace = pg_namespace.oid
-        join pg_stat_all_tables
-            on (pg_class.relname = pg_stat_all_tables.relname AND pg_namespace.nspname = pg_stat_all_tables.schemaname)
-where
-    pg_namespace.nspname not in ('pg_toast')
-order by
-    5 desc
+-- Show last vacuum or autovacuum by table size descending.
+SELECT pg_class.relname
+     , pg_namespace.nspname
+     , pg_size_pretty(pg_total_relation_size(pg_class.oid))
+     , 
+       CASE
+        WHEN COALESCE(last_vacuum,'1/1/1000') >
+         COALESCE(last_autovacuum,'1/1/1000') THEN
+         pg_stat_all_tables.last_vacuum
+       ELSE last_autovacuum
+       END AS last_vacuumed
+     , pg_relation_size(pg_class.oid)
+  FROM pg_class
+  JOIN pg_namespace
+    ON pg_class.relnamespace                 = pg_namespace.oid
+  JOIN pg_stat_all_tables
+    ON (
+        pg_class.relname                      = pg_stat_all_tables.relname
+   AND pg_namespace.nspname                  = pg_stat_all_tables.schemaname
+       )
+ WHERE pg_namespace.nspname not in ('pg_toast')
+ ORDER BY pg_relation_size(pg_class.oid) DESC
 ;

--- a/vacuum/last_autovacuum_and_autoanalyze.sql
+++ b/vacuum/last_autovacuum_and_autoanalyze.sql
@@ -1,19 +1,29 @@
--- Show last autovacuum by table size descending.
-select
-    pg_class.relname,
-    pg_namespace.nspname,
-    pg_size_pretty(pg_total_relation_size(pg_namespace.nspname::text || '.' || pg_class.relname::text)),
-    pg_stat_all_tables.last_autovacuum,
-    pg_stat_all_tables.last_autoanalyze,
-    pg_relation_size(pg_namespace.nspname::text || '.' || pg_class.relname::text)
-from
-    pg_class
-        join pg_namespace
-            on pg_class.relnamespace = pg_namespace.oid
-        join pg_stat_all_tables
-            on (pg_class.relname = pg_stat_all_tables.relname AND pg_namespace.nspname = pg_stat_all_tables.schemaname)
-where
-    pg_namespace.nspname not in ('pg_toast')
-order by
-    5 desc
-;
+-- Show last autovacuum and autoanalyze by table size descending.
+SELECT pg_class.relname
+     , pg_namespace.nspname
+     , pg_size_pretty(pg_total_relation_size(pg_class.oid))
+     , 
+       CASE
+        WHEN COALESCE(last_vacuum,'1/1/1000')  >
+         COALESCE(last_autovacuum,'1/1/1000') THEN
+         pg_stat_all_tables.last_vacuum
+       ELSE last_autovacuum
+       END AS last_vacuumed
+     , 
+       CASE
+        WHEN COALESCE(last_analyze,'1/1/1000') >
+        COALESCE(last_autoanalyze,'1/1/1000') THEN
+        pg_stat_all_tables.last_analyze
+       ELSE last_autoanalyze
+       END AS last_analyzed
+     , pg_relation_size(pg_class.oid)
+  FROM pg_class
+  JOIN pg_namespace
+    ON pg_class.relnamespace                  = pg_namespace.oid
+  JOIN pg_stat_all_tables
+    ON (
+        pg_class.relname                       = pg_stat_all_tables.relname
+   AND pg_namespace.nspname                   = pg_stat_all_tables.schemaname
+       )
+ WHERE pg_namespace.nspname NOT IN ('pg_toast')
+ ORDER BY pg_relation_size(pg_class.oid) DESC ;


### PR DESCRIPTION
Support mixed case table/schema names as well as COALESCE
the most recent of last_(analyze|vacuum) and last_auto(analyze|vacuum) to
give a more useful view of the status.

I also upper cased the keywords and did ran it through the sql formatter.