### PR TITLE
Fix incorrect join condition. We want to join all columns of the inde…

### DIFF
--- a/bloat/index_bloat_check.sql
+++ b/bloat/index_bloat_check.sql
@@ -8,7 +8,6 @@ WITH btree_index_atts AS (
         indrelid, indexrelid,
         indexclass.relam,
         tableclass.relname as tablename,
-        regexp_split_to_table(indkey::text, ' ')::smallint AS attnum,
         indexrelid as index_oid
     FROM pg_index
     JOIN pg_class AS indexclass ON pg_index.indexrelid = indexclass.oid
@@ -32,7 +31,7 @@ index_item_sizes AS (
     END AS index_tuple_hdr,
     sum( (1-coalesce(pg_stats.null_frac, 0)) * coalesce(pg_stats.avg_width, 1024) ) AS nulldatawidth
     FROM pg_attribute
-    JOIN btree_index_atts AS ind_atts ON pg_attribute.attrelid = ind_atts.indexrelid AND pg_attribute.attnum = ind_atts.attnum
+    JOIN btree_index_atts AS ind_atts ON pg_attribute.attrelid = ind_atts.indexrelid 
     JOIN pg_stats ON pg_stats.schemaname = ind_atts.nspname
           -- stats for regular index columns
           AND ( (pg_stats.tablename = ind_atts.tablename AND pg_stats.attname = pg_catalog.pg_get_indexdef(pg_attribute.attrelid, pg_attribute.attnum, TRUE)) 


### PR DESCRIPTION
…x, no matter the column order in the table

The query selects the average length for all columns in the index. At the moment the columns from the index are selected as 
`regexp_split_to_table(indkey::text, ' ')::smallint`, which provides the column numbers from the columns with respect to the table. For example column 10 and column 11. 

When joining with the table `pg_attribute` this gives a problem since this table contains the column numbers with respect to the order within the index. For a index on two columns this would be 1 and 2. Since the orders in the two tables differs, we can't use this as a join condition. 

Since we want to select the average columns width for all columns in the index we can just join all the columns from `pg_attribute`. 